### PR TITLE
Make AppleDebugInfo and AppleSymbolsFileInfo available from outside of rules_apple

### DIFF
--- a/apple/internal/partials/BUILD
+++ b/apple/internal/partials/BUILD
@@ -60,6 +60,7 @@ bzl_library(
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:shell",
         "@build_bazel_apple_support//lib:apple_support",
+        "//apple/internal/providers:apple_symbols_file_info",
     ],
 )
 

--- a/apple/internal/partials/apple_symbols_file.bzl
+++ b/apple/internal/partials/apple_symbols_file.bzl
@@ -35,12 +35,9 @@ load(
     "@build_bazel_rules_apple//apple/internal:processor.bzl",
     "processor",
 )
-
-_AppleSymbolsFileInfo = provider(
-    doc = "Private provider to propagate the transitive .symbols `File`s.",
-    fields = {
-        "symbols_output_dirs": "Depset of `File`s containing directories of $UUID.symbols files for transitive dependencies.",
-    },
+load(
+    "@build_bazel_rules_apple//apple/internal/providers:apple_symbols_file_info.bzl",
+    "AppleSymbolsFileInfo",
 )
 
 def _apple_symbols_file_partial_impl(
@@ -89,9 +86,9 @@ def _apple_symbols_file_partial_impl(
     transitive_output_files = depset(
         direct = outputs,
         transitive = [
-            x[_AppleSymbolsFileInfo].symbols_output_dirs
+            x[AppleSymbolsFileInfo].symbols_output_dirs
             for x in dependency_targets
-            if _AppleSymbolsFileInfo in x
+            if AppleSymbolsFileInfo in x
         ],
     )
 
@@ -102,7 +99,7 @@ def _apple_symbols_file_partial_impl(
 
     return struct(
         bundle_files = bundle_files,
-        providers = [_AppleSymbolsFileInfo(symbols_output_dirs = transitive_output_files)],
+        providers = [AppleSymbolsFileInfo(symbols_output_dirs = transitive_output_files)],
     )
 
 def apple_symbols_file_partial(

--- a/apple/internal/providers/BUILD
+++ b/apple/internal/providers/BUILD
@@ -12,6 +12,16 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 licenses(["notice"])
 
 bzl_library(
+    name = "apple_symbols_file_info",
+    srcs = ["apple_symbols_file_info.bzl"],
+    visibility = [
+        # Visibility set to pkg since this provider is used only
+        # by the `apple_symbols_file` partial.
+        "//apple/internal/partials:__pkg__",
+    ],
+)
+
+bzl_library(
     name = "app_intents_info",
     srcs = ["app_intents_info.bzl"],
     visibility = [

--- a/apple/internal/providers/apple_symbols_file_info.bzl
+++ b/apple/internal/providers/apple_symbols_file_info.bzl
@@ -12,19 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""AppleDebugInfo provider implementation for resource aspect and debug symbols partial support."""
+"""AppleSymbolsFileInfo provider implementation for transitive .symbols `File`s propagation."""
 
-AppleDebugInfo = provider(
-    doc = """
-Private provider to propagate transitive dSYM and link maps information used by the debug symbols
-partial and the resource aspect.
-""",
+AppleSymbolsFileInfo = provider(
+    doc = "Private provider to propagate the transitive .symbols `File`s.",
     fields = {
-        "dsyms": """
-Depset of `File` references to dSYM files if requested in the build with --apple_generate_dsym.
-""",
-        "linkmaps": """
-Depset of `File` references to linkmap files if requested in the build with --objc_generate_linkmap.
-""",
+        "symbols_output_dirs": "Depset of `File`s containing directories of $UUID.symbols files for transitive dependencies.",
     },
 )


### PR DESCRIPTION
Resolve: https://github.com/bazelbuild/rules_apple/issues/2558
Cherry-pick: https://github.com/bazelbuild/rules_apple/pull/2559