### PR TITLE
Verify framework signatures before skipping re-sign (#1953)

### DIFF
--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -223,6 +223,14 @@ sh_binary(
     tags = ["requires-darwin"],
 )
 
+sh_binary(
+    name = "ipa_post_processor_remove_signature",
+    srcs = [
+        "ipa_post_processor_remove_signature.sh",
+    ],
+    tags = ["requires-darwin"],
+)
+
 apple_core_data_model(
     name = "swift_data_model",
     srcs = [

--- a/test/starlark_tests/targets_under_test/apple/ipa_post_processor_remove_signature.sh
+++ b/test/starlark_tests/targets_under_test/apple/ipa_post_processor_remove_signature.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+WORKDIR="$1"
+case "$APPLE_SDK_PLATFORM" in
+  "MacOSX"|"WatchSimulator"|"WatchOS")
+    APPDIR="$WORKDIR"
+    ;;
+  *)
+    APPDIR="$WORKDIR/Payload"
+    ;;
+esac
+
+# Remove the signature from each framework to simulate a post-processor that
+# modifies a framework binary after it was signed, invalidating its signature.
+# The codesigning tool should detect the invalid signature and re-sign the
+# framework instead of skipping it.
+for app in \
+    $(find "$APPDIR" -type d -maxdepth 1 -mindepth 1); do
+
+  if [ "$APPLE_SDK_PLATFORM" != "MacOSX" ]; then
+    FRAMEWORK_DIR="$app/Frameworks"
+  else
+    FRAMEWORK_DIR="$app/Contents/Frameworks"
+  fi
+
+  if [[ -d "$FRAMEWORK_DIR" ]]; then
+    for fmwk in \
+        $(find "$FRAMEWORK_DIR" -type d -maxdepth 1 -mindepth 1); do
+      /usr/bin/codesign --remove-signature "$fmwk"
+    done
+  fi
+done

--- a/test/starlark_tests/targets_under_test/apple/ipa_post_processor_remove_signature.sh
+++ b/test/starlark_tests/targets_under_test/apple/ipa_post_processor_remove_signature.sh
@@ -42,6 +42,7 @@ for app in \
   if [[ -d "$FRAMEWORK_DIR" ]]; then
     for fmwk in \
         $(find "$FRAMEWORK_DIR" -type d -maxdepth 1 -mindepth 1); do
+      /usr/bin/codesign --verify "$fmwk"
       /usr/bin/codesign --remove-signature "$fmwk"
     done
   fi

--- a/test/starlark_tests/targets_under_test/tvos/BUILD
+++ b/test/starlark_tests/targets_under_test/tvos/BUILD
@@ -316,6 +316,21 @@ tvos_application(
 )
 
 tvos_application(
+    name = "app_with_fmwk_post_processor_removes_signature",
+    bundle_id = "com.google.example",
+    frameworks = [":fmwk"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ipa_post_processor = "//test/starlark_tests/targets_under_test/apple:ipa_post_processor_remove_signature",
+    minimum_os_version = common.min_os_tvos.baseline,
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+tvos_application(
     name = "app_structured_resources_and_fmwk_with_structured_resources",
     bundle_id = "com.google.example",
     frameworks = [":fmwk_with_structured_resources"],

--- a/test/starlark_tests/tvos_application_tests.bzl
+++ b/test/starlark_tests/tvos_application_tests.bzl
@@ -107,6 +107,7 @@ def tvos_application_test_suite(name):
         codesign_info_contains = [
             "Identifier=com.google.example.framework",
         ],
+        target_features = ["apple.codesign_frameworks_without_provisioning_profile"],
         tags = [name],
     )
 

--- a/test/starlark_tests/tvos_application_tests.bzl
+++ b/test/starlark_tests/tvos_application_tests.bzl
@@ -97,6 +97,19 @@ def tvos_application_test_suite(name):
         tags = [name],
     )
 
+    # Tests that a framework whose signature was invalidated by a post-processor
+    # (via codesign --remove-signature) is properly re-signed.
+    archive_contents_test(
+        name = "{}_fmwk_post_processor_removes_signature_codesign_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app_with_fmwk_post_processor_removes_signature",
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/fmwk.framework/fmwk",
+        codesign_info_contains = [
+            "Identifier=com.google.example.framework",
+        ],
+        tags = [name],
+    )
+
     # Tests that Swift standard libraries bundled in SwiftSupport have the code
     # signature from Apple.
     archive_contents_test(

--- a/tools/codesigningtool/codesigningtool.py
+++ b/tools/codesigningtool/codesigningtool.py
@@ -320,7 +320,8 @@ def _all_paths_to_sign(targets_to_sign, directories_to_sign):
   return all_paths_to_sign
 
 
-def _filter_paths_already_signed(all_paths_to_sign, signed_paths):
+def _filter_paths_already_signed(all_paths_to_sign, signed_paths,
+                                  codesign_path):
   if set(signed_paths) - set(all_paths_to_sign):
     # TODO(b/151635856): Turn this condition into an error when clang_rt libs
     # for the sanitizers are properly scoped to only the *_application
@@ -328,7 +329,27 @@ def _filter_paths_already_signed(all_paths_to_sign, signed_paths):
     print("WARNING: From the set of all paths to sign, signed frameworks were "
           "not found: %s" % (set(signed_paths) - set(all_paths_to_sign)))
     print("Set of all paths to sign contains: %s" % all_paths_to_sign)
-  return [p for p in all_paths_to_sign if p not in signed_paths]
+
+  # Verify that each signed framework's signature is still valid. A
+  # post-processor (e.g. ipa_post_processor) may have modified the binary
+  # after it was signed, invalidating the signature. Such frameworks need to
+  # be re-signed with the correct identity instead of being skipped.
+  # See: https://github.com/bazelbuild/rules_apple/issues/1953
+  verified_signed_paths = set()
+  for signed_path in signed_paths:
+    if signed_path not in all_paths_to_sign:
+      continue
+    result = subprocess.run(
+        [codesign_path, "--verify", signed_path],
+        capture_output=True,
+    )
+    if result.returncode == 0:
+      verified_signed_paths.add(signed_path)
+    else:
+      print("Re-signing %s (existing signature is invalid, likely modified "
+            "by a post-processor)" % signed_path)
+
+  return [p for p in all_paths_to_sign if p not in verified_signed_paths]
 
 
 def add_parser_arguments(
@@ -420,7 +441,8 @@ def find_identity_and_sign_bundle_paths(args: argparse.Namespace) -> int:
   signed_path = args.signed_path
   if signed_path:
     all_paths_to_sign = _filter_paths_already_signed(all_paths_to_sign,
-                                                     signed_path)
+                                                     signed_path,
+                                                     args.codesign)
 
   for path_to_sign in all_paths_to_sign:
     invoke_codesign(


### PR DESCRIPTION
The `ipa_post_processor` runs before `rules_apple`'s signing step. 
We strip binaries (`strip -rSTx`) in `ipa_post_processor` to reduce app size, which invalidates the
framework signatures applied during each framework's own build target.
`rules_apple`'s signing step then skips those frameworks because they are listed in `signed_frameworks` - a depset
computed at analysis time, unaware that the `ipa_post_processor` modified them. 

See: https://github.com/bazelbuild/rules_apple/issues/1953